### PR TITLE
schema(fly): Allow numbers and strings in kill_timeout

### DIFF
--- a/src/schemas/json/fly.json
+++ b/src/schemas/json/fly.json
@@ -232,7 +232,13 @@
     },
     "kill_timeout": {
       "description": "Seconds to wait before forcing a VM process to exit. Default is 5 seconds.",
-      "type": "integer"
+      "oneOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "string"
+        }
     },
     "kill_signal": {
       "description": "Signal to send to a process to shut it down gracefully. Default is SIGINT.",

--- a/src/schemas/json/fly.json
+++ b/src/schemas/json/fly.json
@@ -239,6 +239,7 @@
         {
           "type": "string"
         }
+      ]
     },
     "kill_signal": {
       "description": "Signal to send to a process to shut it down gracefully. Default is SIGINT.",


### PR DESCRIPTION
Fly's configuration file allows both numbers (5 seconds) and strings ("5s") for the `kill_timeout` table field.

I noticed this because it actually seems like the string version is its internal representation, as that is what is produced by `fly config save` when migrating to Fly.io's Apps V2 platform.

cc: @superfly @mrkurt (just fyi)